### PR TITLE
Remove unmaintained links

### DIFF
--- a/source/install.html.haml
+++ b/source/install.html.haml
@@ -22,29 +22,11 @@ no_container: true
         Mac
 
       %li
-        = link_to 'Hammer', 'http://hammerformac.com/'
-        (Paid)
-        Mac
-
-      %li
-        = link_to 'LiveReload', 'http://livereload.com/'
-        (Paid, Open Source)
-        Mac
-        Windows
-
-      %li
         = link_to 'Prepros', 'https://prepros.io/'
         (Paid)
         Mac
         Windows
         Linux
-
-      %li
-        = link_to 'Scout-App', 'http://scout-app.io/'
-        (Free, Open Source)
-        Windows
-        Linux
-        Mac
 
     :markdown
       ## Libraries


### PR DESCRIPTION
- Hammer and LiveReload are unmaintained and their websites are dead.
- Scout-App's website is still up, but it is also unmaintained and still uses old libsass.